### PR TITLE
fix infinite loop bug.

### DIFF
--- a/src/main/java/org/codelibs/fess/ds/s3/AmazonS3Client.java
+++ b/src/main/java/org/codelibs/fess/ds/s3/AmazonS3Client.java
@@ -129,8 +129,8 @@ public class AmazonS3Client implements AutoCloseable {
             if (!response.isTruncated()) {
                 break;
             }
-            final String next = response.nextContinuationToken();
-            response = client.listObjectsV2(builder -> builder.bucket(bucket).fetchOwner(true).maxKeys(maxKeys).startAfter(next).build());
+            final S3Object lastObj = response.contents().get(response.contents().size() - 1);
+            response = client.listObjectsV2(builder -> builder.bucket(bucket).fetchOwner(true).maxKeys(maxKeys).startAfter(lastObj.key()).build());
         }
     }
 


### PR DESCRIPTION
I found an infinite loop bug in AmazonS3Client#getObjects() and I fixed it.

Before the fix, this method loop infinitely if there are more than maxKeys (default value is 1000) files in the S3 bucket.